### PR TITLE
Feature/app keyword 키워드 직접 입력 기능

### DIFF
--- a/app/fronted/Boost2Note.py
+++ b/app/fronted/Boost2Note.py
@@ -114,7 +114,6 @@ with con2:
             st.session_state["keywords"],
         )
         input_keywords = st_tags(label="키워드 직접 입력", text="Press enter to add more")
-        st.write(input_keywords)
         keywords_set = list(set(options + [i.strip(" ") for i in input_keywords if i.strip(" ") != ""]))
         # 띄어쓰기 제거 및 중복 제거
 

--- a/app/fronted/Boost2Note.py
+++ b/app/fronted/Boost2Note.py
@@ -115,7 +115,7 @@ with con2:
         )
         input_keywords = st_tags(label="키워드 직접 입력", text="Press enter to add more")
         st.write(input_keywords)
-        keywords_set = list(set(options + [i.strip(" ") for i in input_keywords if i != " "]))
+        keywords_set = list(set(options + [i.strip(" ") for i in input_keywords if i.strip(" ") != ""]))
         # 띄어쓰기 제거 및 중복 제거
 
     else:

--- a/app/fronted/Boost2Note.py
+++ b/app/fronted/Boost2Note.py
@@ -114,8 +114,10 @@ with con2:
             st.session_state["keywords"],
         )
         input_keywords = st_tags(label="키워드 직접 입력", text="Press enter to add more")
-        keywords_set = set(options + [i.strip(" ") for i in input_keywords if i != ""])
+        st.write(input_keywords)
+        keywords_set = list(set(options + [i.strip(" ") for i in input_keywords if i != " "]))
         # 띄어쓰기 제거 및 중복 제거
+
     else:
         options = st.multiselect(
             "주요 키워드",
@@ -132,6 +134,6 @@ with con2:
 
     with con8:
         if st.button("요약하기", key="summarization"):
-            response = requests.post("http://localhost:8000/summarize", json={"keywords": (keywords_set)})
+            response = requests.post("http://localhost:8000/summarize", json={"keywords": keywords_set})
             json_res = json.loads(response.text)  # json_res : list
             call(con2, expanders, json_res)

--- a/app/fronted/Boost2Note.py
+++ b/app/fronted/Boost2Note.py
@@ -6,6 +6,7 @@ from collections import deque
 import requests
 import streamlit as st
 import streamlit_nested_layout
+from streamlit_tags import st_tags
 
 __all__ = ["streamlit_nested_layout"]
 
@@ -112,12 +113,15 @@ with con2:
             "주요 키워드",
             st.session_state["keywords"],
         )
+        input_keywords = st_tags(label="키워드 직접 입력", text="Press enter to add more")
+        keywords_set = set(options + [i.strip(" ") for i in input_keywords])
     else:
         options = st.multiselect(
             "주요 키워드",
             list(queue),
             # ["nnew"],
         )
+
     con8, _ = st.columns([0.8, 0.2])
     expanders = []
     for i in range(3):
@@ -127,6 +131,6 @@ with con2:
 
     with con8:
         if st.button("요약하기", key="summarization"):
-            response = requests.post("http://localhost:8000/summarize", json={"keywords": options})
+            response = requests.post("http://localhost:8000/summarize", json={"keywords": (keywords_set)})
             json_res = json.loads(response.text)  # json_res : list
             call(con2, expanders, json_res)

--- a/app/fronted/Boost2Note.py
+++ b/app/fronted/Boost2Note.py
@@ -114,7 +114,8 @@ with con2:
             st.session_state["keywords"],
         )
         input_keywords = st_tags(label="키워드 직접 입력", text="Press enter to add more")
-        keywords_set = set(options + [i.strip(" ") for i in input_keywords])
+        keywords_set = set(options + [i.strip(" ") for i in input_keywords if i != ""])
+        # 띄어쓰기 제거 및 중복 제거
     else:
         options = st.multiselect(
             "주요 키워드",

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,6 @@ rouge==1.0.1
 rouge-score==0.1.2
 sentence-transformers==2.2.2
 streamlit-nested-layout==0.1.1
+streamlit_tags==1.2.8
 utils==1.0.1
 uvicorn==0.20.0


### PR DESCRIPTION
## ⚠️ Problem Statement

keybert로 키워드 추출 시 나오지 않는 키워드 있을 수 있음

## 🔧 Methodology

사용자가 직접 키워드를 입력하여 선택할 수 있게 함

## 🚧 TODO LIST

## ⚗️ Experiment Setup & Results

```python
input_keywords = st_tags(label="키워드 직접 입력", text="Press enter to add more")
keywords_set = set(options + [i.strip(" ") for i in input_keywords if i != ""])  # 띄어쓰기 제거 및 중복 제거
```
- st_tags로 태그 입력
- 띄어쓰기, 중복 단어, 빈 배열 제거

![image](https://user-images.githubusercontent.com/69241185/217031921-c1550572-fb41-42b4-a3e9-5a58a27be951.png)

![image](https://user-images.githubusercontent.com/69241185/217032022-2e47e8ec-36d2-4d47-ae33-f0d455be9f7a.png)


## 🔀 Conclusion

<!-- 실험에 따른 결론과 대안 -->
### 개선점
- 첫 페이지에는 입력 박스가 나오지 않음 
  -> st_tags에 disabled 기능이 없어서 일단 입력하지 못하게 없앰

## 🧩 Related Works

<!-- 참고 문헌 -->

## 📄 Related Issue

<!-- 관련 PR 링크 작성 -->

