### PR TITLE
fix: keybert get_candidates 예외처리

### DIFF
--- a/app/backend/app_utils/key_bert.py
+++ b/app/backend/app_utils/key_bert.py
@@ -14,9 +14,11 @@ def get_candidates(text):
     tokenized_nouns = " ".join(
         [word[0] for word in tokenized_doc if word[1] in ["NNP", "NNG", "SL"]]
     )  # 일반명사, 고유명사, 외국어
+    if len(tokenized_nouns) == 0:
+        return [""]
 
     n_gram_range = (1, 1)
-    count = CountVectorizer(ngram_range=n_gram_range).fit([tokenized_nouns])
+    count = CountVectorizer(ngram_range=n_gram_range, token_pattern=r"(?u)\b\w+\b").fit([tokenized_nouns])
     candidates = count.get_feature_names_out()
     return candidates
 


### PR DESCRIPTION
## ⚠️ Problem Statement

keybert 오류 hotfix

## 🔧 Methodology

<!-- 해결하고자 하는 방안 -->
입력 문장에서 명사구가 한 글자 또는 없을 때 오류 해결

## 🚧 TODO LIST

## ⚗️ Experiment Setup & Results

관련 이슈 #35 

## 🔀 Conclusion

<!-- 실험에 따른 결론과 대안 -->
- 명사구 미추출 시 빈배열 반환
- 한 글자 추출 가능

## 🧩 Related Works

<!-- 참고 문헌 -->

## 📄 Related Issue

<!-- 관련 PR 링크 작성 -->
close #35 
