### PR TITLE
STT post-processing

### DIFF
--- a/app/backend/app_utils/__init__.py
+++ b/app/backend/app_utils/__init__.py
@@ -1,4 +1,4 @@
-from .cache_load import load_model, load_retriever, load_sbert, load_stt_model
+from .cache_load import load_model, load_retriever, load_sbert, load_small_stt_model
 from .data_process import create_context_embedding, split_passages
 from .inference import summarize_fid
 from .key_bert import get_keyword
@@ -7,7 +7,7 @@ from .stt import predict_stt
 __all__ = [
     load_model,
     load_retriever,
-    load_stt_model,
+    load_small_stt_model,
     summarize_fid,
     predict_stt,
     load_sbert,

--- a/app/backend/app_utils/cache_load.py
+++ b/app/backend/app_utils/cache_load.py
@@ -38,8 +38,13 @@ def load_tokenizer():
 
 
 @lru_cache
-def load_stt_model():
+def load_large_stt_model():
     return whisper.load_model("large")
+
+
+@lru_cache
+def load_small_stt_model():
+    return whisper.load_model("small")
 
 
 @lru_cache

--- a/app/backend/app_utils/data_process.py
+++ b/app/backend/app_utils/data_process.py
@@ -58,12 +58,7 @@ def get_sentence_embedding(model, text: list, batch_size: int = 16) -> torch.Ten
     return torch.cat(embeddings).squeeze()
 
 
-def split_passages(segments, threshold=0.5):
-    if len(segments) <= 1:
-        return segments[0]["text"]
-    passages = []
-    for segment in segments:
-        passages.append(segment["text"])
+def split_passages(passages, threshold=0.5):
     model = load_sbert()
     embedding = get_sentence_embedding(model=model, text=passages, batch_size=16)
     emb_len = len(embedding)

--- a/app/backend/app_utils/stt.py
+++ b/app/backend/app_utils/stt.py
@@ -56,6 +56,9 @@ def predict_stt(soundfile: bytes) -> list:
 
 
 def split_sentences(text: List[str]) -> List[str]:
+    """
+    500자 이상인 경우 hanspell.spell_checker() 함수가 동작하지 않으므로 500자 이하로 구분
+    """
     content_list = [""]
 
     for t in text:

--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -44,8 +44,9 @@ def startup_event():
     load_retriever()
     print("FiD model loaded")
     load_small_stt_model()
+    print("Whisper model loaded")
     load_sbert()
-    print("success to loading whisper model")
+    print("success to load model")
 
 
 @app.on_event("shutdown")

--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -8,7 +8,7 @@ from app_utils import (
     load_model,
     load_retriever,
     load_sbert,
-    load_stt_model,
+    load_small_stt_model,
     predict_stt,
     split_passages,
     summarize_fid,
@@ -43,7 +43,7 @@ def startup_event():
     load_model(model_type="sbert")
     load_retriever()
     print("FiD model loaded")
-    load_stt_model()
+    load_small_stt_model()
     load_sbert()
     print("success to loading whisper model")
 


### PR DESCRIPTION
## ⚠️ Problem Statement

<!-- 이 작업을 수행하여 해결하려는 문제 -->
- STT 변환 시, whisper large model을 small model로 변경하고 후처리하여 **STT 변환 품질은 최대한 보존하되, 변환 속도 개선**
- STT 변환 후, 적절히 문장을 분리하여 비슷한 의미끼리 문단을 분리하는 **문단 분리 성능 향상**

## 🔧 Methodology

<!-- 해결하고자 하는 방안 -->

1. STT 변환 시 whisper large model → small model 변경
2. `py-hanspell`을 이용해 post processing (맞춤법 및 띄어쓰기 교정)
3. 한글 문장 분리기 `kss`를 이용해 문장을 분리

## 🚧 TODO LIST

- [x] whisper load model을 large에서 small로 변경
- [x] py-hanspell 적용
- [x] kss 적용, 문장 간 띄어쓰기 추가
- [x] 테스트

## 🔀 Conclusion

<!-- 실험에 따른 결론과 대안 -->
1. `STT 변환 속도 기존 대비 54% 감소` : 
    - large model, 후처리 X, 오디오 파일 업로드 후 변환하기까지 소요 시간 :`7분 30초`
    - small model, 후처리 O, 오디오 파일 업로드 후 변환하기까지 소요 시간 : `3분 28초`
2. `STT 변환 품질` 및 `문단 분리 성능` 비교
> before
<img width="300" height="600" alt="" src="https://user-images.githubusercontent.com/54230911/218269827-49cd10fb-51cf-41ca-bfef-c5405c0a7b1f.png">
<img width="300" height="300" alt="" src="https://user-images.githubusercontent.com/54230911/218269842-69f2546d-663d-46f8-b6fc-90487127d5bd.png">

> after
<img width="800" alt="" src="https://user-images.githubusercontent.com/54230911/218269854-394498d0-5c76-476a-bf66-9a2f5eb23563.png">

## ⚗️ Experiment Setup & Results

```bash
# whisper 설치
pip install -U openai-whisper
sudo apt update && sudo apt install ffmpeg
pip install setuptools-rust

# py-hanspell 설치
git clone https://github.com/ssut/py-hanspell
cd py-hanspell
python setup.py install
```

1. kss로 문장 분리
> before

<img width="500" alt="" src="https://user-images.githubusercontent.com/54230911/218270617-dadf7f66-04f3-4911-bd85-e81aa8619d69.png">

> after

![kss_after](https://user-images.githubusercontent.com/54230911/218270628-fa5d768e-a77c-4d97-9231-5b52eac0dcbf.png)


2. 문장 간 띄어쓰기 추가
- `kss`로 split한 후 문단 분리에 적용하면 모든 문장이 마침표를 기준으로 붙어서 나오므로 문장 간 공백을 추가해줌

> before

![image](https://user-images.githubusercontent.com/54230911/218270762-cb0e5f8e-e55c-4056-b030-998754bd9c22.png)

> after

![image](https://user-images.githubusercontent.com/54230911/218270770-eb397dbf-c515-4e8f-8eb5-684fe4a85819.png)

3. `py-hanspell` 적용 시 문자열 길이가 500자 이상인 경우 맞춤법 및 띄어쓰기 교정 함수인 `spell_checker()` 동작하지 않음
→ 길이를 500자 이하로 맞춰줌

## 🧩 Related Works

- STT API [openai/whisper](https://github.com/openai/whisper)
- 맞춤법 교정 [py-hanspell](https://github.com/ssut/py-hanspell)
- 한글 문장 분리기 [kss](https://github.com/likejazz/korean-sentence-splitter)

## 📄 Related Issue

close #34 
