### PR TITLE
fix: Fix url of stt to work well with Nginx

### DIFF
--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -58,8 +58,9 @@ def read_root():
     return {"Hello": "World"}
 
 
-@app.post("/stt/")
+@app.post("/stt")
 async def get_passages(files: List[bytes] = File()) -> List:
+    print("stt started")
     results = []
     keywords = set()
     passages = set()
@@ -81,6 +82,7 @@ async def get_passages(files: List[bytes] = File()) -> List:
 
 @app.post("/summarize")
 async def summarize_text(keywords: Keywords, response_model=SummarizeResponse):
+    print("summarize started")
     sample_num = 3
     dict_keys = dict(keywords)
     keywords = np.array(dict_keys["keywords"])
@@ -99,4 +101,4 @@ async def summarize_text(keywords: Keywords, response_model=SummarizeResponse):
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=30002)

--- a/app/frontend/Boost2Note.py
+++ b/app/frontend/Boost2Note.py
@@ -13,6 +13,8 @@ sys.path.insert(0, ".")
 queue = deque()
 st.set_page_config(layout="wide")
 
+port = 30008
+address = ""
 
 # =======
 #   App
@@ -119,7 +121,7 @@ with con_stt:
                 for uploaded_file in uploaded_files:
                     sound_bytes = uploaded_file.getvalue()
                     files.append(("files", (uploaded_file.name, sound_bytes, uploaded_file.type)))
-                response = requests.post("http://localhost:8000/stt", files=files)
+                response = requests.post(f"{address}/stt", files=files)
                 result = response.json()
                 print(result)
                 st.session_state["stt_disabled"] = False
@@ -159,7 +161,7 @@ with con2:
         msg = "요약 중입니다.."
         warning_placeholder = st.empty()
         warning_placeholder.warning(msg, icon="🤖")
-        response = requests.post("http://localhost:8000/summarize", json={"keywords": keywords_set})
+        response = requests.post(f"{address}/summarize", json={"keywords": keywords_set})
         json_res = json.loads(response.text)  # json_res : list
         warning_placeholder.empty()
         print(json_res)


### PR DESCRIPTION
## ⚠️ Problem Statement
Backend 서버에서 `/stt` 에 대한 요청을 받을 때, 요청은 받지만 nginx가 응답을 받지 못하는 문제

## 🔧 Methodology
`/stt/`로 명시되어 있는 url path를 `/stt`로 변경하여 문제를 해결함
## 🚧 TODO LIST

## ⚗️ Experiment Setup & Results

<!-- 실험(적용) 과정과 결과 -->

## 🔀 Conclusion

<!-- 실험에 따른 결론과 대안 -->

## 🧩 Related Works

<!-- 참고 문헌 -->

## 📄 Related Issue

<!-- 관련 PR 링크 작성 -->
close #{ISSUE_NUMBER}
