### PR TITLE
fix: server port 연결

### DIFF
--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -101,4 +101,4 @@ async def summarize_text(keywords: Keywords, response_model=SummarizeResponse):
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=30002)
+    uvicorn.run(app, host="0.0.0.0", port=30001)

--- a/app/frontend/Boost2Note.py
+++ b/app/frontend/Boost2Note.py
@@ -13,8 +13,8 @@ sys.path.insert(0, ".")
 queue = deque()
 st.set_page_config(layout="wide")
 
-port = 30008
-address = ""
+port = 30001  # nginx 서버 port로 설정
+address = ""  # "http://{본인 서버 IP 주소}" 설정
 
 # =======
 #   App

--- a/app/frontend/Boost2Note.py
+++ b/app/frontend/Boost2Note.py
@@ -13,8 +13,8 @@ sys.path.insert(0, ".")
 queue = deque()
 st.set_page_config(layout="wide")
 
-port = 30001  # nginx 서버 port로 설정
-address = ""  # "http://{본인 서버 IP 주소}" 설정
+port = 30001  # backend 서버 port와 동일하게 설정 (POST 통신 port)
+address = ""  # "http://{본인 서버 IP 주소}"로 설정
 
 # =======
 #   App
@@ -121,7 +121,7 @@ with con_stt:
                 for uploaded_file in uploaded_files:
                     sound_bytes = uploaded_file.getvalue()
                     files.append(("files", (uploaded_file.name, sound_bytes, uploaded_file.type)))
-                response = requests.post(f"{address}/stt", files=files)
+                response = requests.post(f"{address}:{port}/stt", files=files)
                 result = response.json()
                 print(result)
                 st.session_state["stt_disabled"] = False
@@ -161,7 +161,7 @@ with con2:
         msg = "요약 중입니다.."
         warning_placeholder = st.empty()
         warning_placeholder.warning(msg, icon="🤖")
-        response = requests.post(f"{address}/summarize", json={"keywords": keywords_set})
+        response = requests.post(f"{address}:{port}/summarize", json={"keywords": keywords_set})
         json_res = json.loads(response.text)  # json_res : list
         warning_placeholder.empty()
         print(json_res)


### PR DESCRIPTION
## ⚠️ Problem Statement

<!-- 이 작업을 수행하여 해결하려는 문제 -->


## 🔧 Methodology

<!-- 해결하고자 하는 방안 -->
### 실행 예시 순서

1. backend `server.py` : `uvicorn.run(app, host="0.0.0.0", port=30001)` 로 설정
2. `python3 server.py` 실행
3. frontend `Boost2Note.py` : backend 서버와 POST 통신을 하는 `port = 30001`, `address = "http://{본인 서버 IP 주소}”` 변수 설정 (ex. "http://118.67.132.27")
4. backend 서버 실행이 완료된 후, `streamlit run Boost2Note.py --server.port 30003 --server.fileWatcherType none` 실행

        주의 : streamlit 실행할 때 port 번호는 frontend-backend 통신 port와 다르게 설정
5. `response = requests.post(f"{address}/stt", files=files)`, `response = requests.post(f"{address}/summarize", json={"keywords": keywords_set})` 로 post 방식으로 backend 서버로 파일 전송할 때 address 뒤에 port 번호 추가

        stt, summarize 버튼에 모두 변경하여 적용

## 🚧 TODO LIST


## ⚗️ Experiment Setup & Results

<!-- 실험(적용) 과정과 결과 -->

## 🔀 Conclusion

<!-- 실험에 따른 결론과 대안 -->
- nginx까지 적용해서 실행하는 방법 추후 업로드 필요

## 🧩 Related Works

<!-- 참고 문헌 -->

## 📄 Related Issue

<!-- 관련 PR 링크 작성 -->
close #48 
